### PR TITLE
Add mock Google Places restaurants data

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,6 +13,7 @@ import { Lato_400Regular } from '@expo-google-fonts/lato';
 import { theme } from './src/infrastructure/theme';
 import { SafeArea } from './src/components/SafeArea/SafeArea';
 import { RestaurantsScreen } from './src/features/restaurants/screens/RestaurantsScreen';
+import { RestaurantsContextProvider } from './src/services/restaurants/RestaurantsContext';
 
 const TAB_ICON = {
   Restaurants: 'restaurant',
@@ -57,19 +58,21 @@ export default function App() {
     return (
       <>
         <ThemeProvider theme={theme}>
-          <NavigationContainer>
-            <Tab.Navigator
-              screenOptions={createScreenOptions}
-              tabBarOptions={{
-                activeTintColor: 'tomato',
-                inactiveTintColor: 'gray',
-              }}
-            >
-              <Tab.Screen name="Restaurants" component={RestaurantsScreen} />
-              <Tab.Screen name="Map" component={Map} />
-              <Tab.Screen name="Settings" component={Settings} />
-            </Tab.Navigator>
-          </NavigationContainer>
+          <RestaurantsContextProvider>
+            <NavigationContainer>
+              <Tab.Navigator
+                screenOptions={createScreenOptions}
+                tabBarOptions={{
+                  activeTintColor: 'tomato',
+                  inactiveTintColor: 'gray',
+                }}
+              >
+                <Tab.Screen name="Restaurants" component={RestaurantsScreen} />
+                <Tab.Screen name="Map" component={Map} />
+                <Tab.Screen name="Settings" component={Settings} />
+              </Tab.Navigator>
+            </NavigationContainer>
+          </RestaurantsContextProvider>
         </ThemeProvider>
         <ExpoStatusBar style="auto" />
       </>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^5.11.11",
     "@react-navigation/native": "^5.9.4",
+    "camelize": "^1.0.0",
     "expo": "~41.0.1",
     "expo-app-loading": "^1.0.3",
     "expo-font": "~9.1.0",

--- a/src/features/restaurants/screens/RestaurantsScreen.js
+++ b/src/features/restaurants/screens/RestaurantsScreen.js
@@ -1,10 +1,11 @@
 import React, { useContext } from 'react';
 import { FlatList, View } from 'react-native';
-import { Searchbar } from 'react-native-paper';
+import { Searchbar, ActivityIndicator, Colors } from 'react-native-paper';
 import styled from 'styled-components/native';
 
 import { SafeArea } from '../../../components/SafeArea/SafeArea';
 import { Spacer } from '../../../components/Spacer/Spacer';
+import { RestaurantInfoCard } from '../components/RestaurantInfoCard';
 
 import { RestaurantsContext } from '../../../services/restaurants/RestaurantsContext';
 
@@ -19,13 +20,26 @@ const RestaurantList = styled(FlatList).attrs({
   },
 })``;
 
-import { RestaurantInfoCard } from '../components/RestaurantInfoCard';
+const LoadingContainer = styled(View)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+`;
+
+const Loading = styled(ActivityIndicator)`
+  margin-left: -25px;
+`;
 
 export const RestaurantsScreen = () => {
-  const { restaurants } = useContext(RestaurantsContext);
+  const { restaurants, isLoading } = useContext(RestaurantsContext);
 
   return (
     <SafeArea>
+      {isLoading && (
+        <LoadingContainer>
+          <Loading size={50} animating={true} color={Colors.blue300} />
+        </LoadingContainer>
+      )}
       <SearchContainer>
         <Searchbar placeholder="Search" />
       </SearchContainer>

--- a/src/features/restaurants/screens/RestaurantsScreen.js
+++ b/src/features/restaurants/screens/RestaurantsScreen.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { FlatList, View } from 'react-native';
 import { Searchbar } from 'react-native-paper';
 import styled from 'styled-components/native';
 
 import { SafeArea } from '../../../components/SafeArea/SafeArea';
 import { Spacer } from '../../../components/Spacer/Spacer';
+
+import { RestaurantsContext } from '../../../services/restaurants/RestaurantsContext';
 
 const SearchContainer = styled(View)`
   padding: ${(props) => props.theme.space[3]};
@@ -19,30 +21,26 @@ const RestaurantList = styled(FlatList).attrs({
 
 import { RestaurantInfoCard } from '../components/RestaurantInfoCard';
 
-export const RestaurantsScreen = () => (
-  <SafeArea>
-    <SearchContainer>
-      <Searchbar placeholder="Search" />
-    </SearchContainer>
-    <RestaurantList
-      data={[
-        { name: 1 },
-        { name: 2 },
-        { name: 3 },
-        { name: 4 },
-        { name: 5 },
-        { name: 6 },
-        { name: 7 },
-        { name: 8 },
-        { name: 9 },
-        { name: 10 },
-      ]}
-      renderItem={() => (
-        <Spacer position="bottom" size="large">
-          <RestaurantInfoCard />
-        </Spacer>
-      )}
-      keyExtractor={(item) => item.name}
-    />
-  </SafeArea>
-);
+export const RestaurantsScreen = () => {
+  const { restaurants } = useContext(RestaurantsContext);
+
+  return (
+    <SafeArea>
+      <SearchContainer>
+        <Searchbar placeholder="Search" />
+      </SearchContainer>
+      <RestaurantList
+        data={restaurants}
+        renderItem={({ item }) => {
+          console.log(item);
+          return (
+            <Spacer position="bottom" size="large">
+              <RestaurantInfoCard restaurant={item} />
+            </Spacer>
+          );
+        }}
+        keyExtractor={(item) => item.name}
+      />
+    </SafeArea>
+  );
+};

--- a/src/services/restaurants/RestaurantsContext.js
+++ b/src/services/restaurants/RestaurantsContext.js
@@ -1,0 +1,40 @@
+import React, { useState, useEffect, createContext } from 'react';
+
+import {
+  restaurantsRequest,
+  restaurantsTransform,
+} from './restaurants.service';
+
+export const RestaurantsContext = createContext();
+
+export const RestaurantsContextProvider = ({ children }) => {
+  const [restaurants, setRestaurants] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const retrieveRestaurants = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      restaurantsRequest()
+        .then(restaurantsTransform)
+        .then((results) => {
+          setIsLoading(false);
+          setRestaurants(results);
+        })
+        .catch((err) => {
+          setIsLoading(false);
+          setError(err);
+        });
+    }, 2000);
+  };
+
+  useEffect(() => {
+    retrieveRestaurants();
+  }, []);
+
+  return (
+    <RestaurantsContext.Provider value={{ restaurants, isLoading, error }}>
+      {children}
+    </RestaurantsContext.Provider>
+  );
+};

--- a/src/services/restaurants/mock/antwerp.json
+++ b/src/services/restaurants/mock/antwerp.json
@@ -1,0 +1,875 @@
+{
+  "html_attributions": [],
+  "next_page_token": "some token",
+  "results": [
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2132707,
+          "lng": 4.4168305
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2145994302915,
+            "lng": 4.418074130291502
+          },
+          "southwest": {
+            "lat": 51.2119014697085,
+            "lng": 4.415376169708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Mercure Antwerp City Centre",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 1",
+      "rating": 4,
+      "reference": "",
+      "user_ratings_total": 832,
+      "vicinity": "Quinten Matsijslei 25, Antwerpen"
+    },
+    {
+      "geometry": {
+        "location": {
+          "lat": 51.21366200000001,
+          "lng": 4.405177
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2150259802915,
+            "lng": 4.406393180291502
+          },
+          "southwest": {
+            "lat": 51.2123280197085,
+            "lng": 4.403695219708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Elzenveld Hotel & Seminar",
+      "photos": [
+        {
+          "height": 1536,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 2",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "reference": "",
+      "scope": "",
+      "types": [
+        "spa",
+        "lodging",
+        "restaurant",
+        "food",
+        "gym",
+        "health",
+        "point_of_interest",
+        "establishment"
+      ],
+      "vicinity": "Lange Gasthuisstraat 45, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.220671,
+          "lng": 4.399616700000001
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2220094802915,
+            "lng": 4.400740480291502
+          },
+          "southwest": {
+            "lat": 51.2193115197085,
+            "lng": 4.398042519708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "HotelO",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 2000,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3000
+        }
+      ],
+      "place_id": "some place id 3",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "travel_agency",
+        "lodging",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 321,
+      "vicinity": "Handschoenmarkt 3/5, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2093238,
+          "lng": 4.39107
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2107127302915,
+            "lng": 4.392468230291503
+          },
+          "southwest": {
+            "lat": 51.2080147697085,
+            "lng": 4.389770269708499
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "The Glorious Inn",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 4",
+      "rating": 4.6,
+      "reference": "",
+      "user_ratings_total": 152,
+      "vicinity": "De Burburestraat 4A, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2085756,
+          "lng": 4.3922755
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2098682302915,
+            "lng": 4.393753530291503
+          },
+          "southwest": {
+            "lat": 51.2071702697085,
+            "lng": 4.391055569708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Hotel Pilar",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 5",
+      "rating": 4.2,
+      "reference": "",
+
+      "user_ratings_total": 151,
+      "vicinity": "Leopold de Waelplaats 34, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2210731,
+          "lng": 4.4030571
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2224264802915,
+            "lng": 4.404163080291502
+          },
+          "southwest": {
+            "lat": 51.2197285197085,
+            "lng": 4.401465119708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "De Peerdestal | Restaurant Antwerpen",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 6",
+      "price_level": 2,
+      "rating": 4.3,
+      "reference": "",
+      "user_ratings_total": 766,
+      "vicinity": "Wijngaardstraat 8, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.215643,
+          "lng": 4.399512000000001
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.21704323029149,
+            "lng": 4.400861330291503
+          },
+          "southwest": {
+            "lat": 51.2143452697085,
+            "lng": 4.398163369708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Huis De Colvenier",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 7",
+      "rating": 4.2,
+      "reference": "",
+      "user_ratings_total": 122,
+      "vicinity": "Sint-Antoniusstraat 8, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.21939859999999,
+          "lng": 4.3991545
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2206672302915,
+            "lng": 4.400538980291503
+          },
+          "southwest": {
+            "lat": 51.2179692697085,
+            "lng": 4.397841019708499
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Il Milanese by Lollapalooza",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 8",
+      "price_level": 2,
+      "rating": 4.4,
+      "reference": "",
+      "user_ratings_total": 156,
+      "vicinity": "Pelgrimstraat 28, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2205556,
+          "lng": 4.401666699999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2219723802915,
+            "lng": 4.403506180291502
+          },
+          "southwest": {
+            "lat": 51.2192744197085,
+            "lng": 4.400808219708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Het Vermoeide Model",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 0,
+          "html_attributions": [],
+          "photo_reference": "",
+          "width": 0
+        }
+      ],
+      "place_id": "some place id 9",
+      "price_level": 2,
+      "rating": 3.8,
+      "reference": "",
+      "user_ratings_total": 441,
+      "vicinity": "Lijnwaadmarkt 2, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.21901699999999,
+          "lng": 4.399416899999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2203960302915,
+            "lng": 4.400800780291502
+          },
+          "southwest": {
+            "lat": 51.2176980697085,
+            "lng": 4.398102819708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "'t Fornuis",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 1536,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 10",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 4,
+      "rating": 4.7,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 152,
+      "vicinity": "Reyndersstraat 24, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2141321,
+          "lng": 4.409785100000001
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2154825302915,
+            "lng": 4.410900480291502
+          },
+          "southwest": {
+            "lat": 51.2127845697085,
+            "lng": 4.408202519708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Lunchbox",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 3139,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 6153
+        }
+      ],
+      "place_id": "some place id 11",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "restaurant",
+        "bar",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 689,
+      "vicinity": "Nieuwstad 8, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.21892750000001,
+          "lng": 4.3944361
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2201378802915,
+            "lng": 4.396247430291502
+          },
+          "southwest": {
+            "lat": 51.2174399197085,
+            "lng": 4.393549469708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Zuiderterras / RAS",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 4032,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3024
+        }
+      ],
+      "place_id": "some place id 12",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "restaurant",
+        "cafe",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 854,
+      "vicinity": "Ernest Van Dijckkaai 37, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.22667930000001,
+          "lng": 4.406515799999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2281167302915,
+            "lng": 4.407858080291502
+          },
+          "southwest": {
+            "lat": 51.2254187697085,
+            "lng": 4.405160119708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Pazzo",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 639,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1136
+        }
+      ],
+      "place_id": "some place id 13",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 316,
+      "vicinity": "Oudeleeuwenrui 12, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2164307,
+          "lng": 4.409301300000001
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2178396302915,
+            "lng": 4.410637980291503
+          },
+          "southwest": {
+            "lat": 51.2151416697085,
+            "lng": 4.407940019708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Horta Grand Café & Art Nouveau Zaal",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3376,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 6000
+        }
+      ],
+      "place_id": "some place id 14",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.1,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 1274,
+      "vicinity": "Hopland 2, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.220236,
+          "lng": 4.399357
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2218302802915,
+            "lng": 4.400721680291503
+          },
+          "southwest": {
+            "lat": 51.2191323197085,
+            "lng": 4.398023719708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Sir Anthony Van Dijck",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 720,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 480
+        }
+      ],
+      "place_id": "some place id 15",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 4,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 311,
+      "vicinity": "Oude Koornmarkt 16, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2129287,
+          "lng": 4.3923955
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2142454302915,
+            "lng": 4.393706330291502
+          },
+          "southwest": {
+            "lat": 51.2115474697085,
+            "lng": 4.391008369708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Mañana Mañana",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 683,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1024
+        }
+      ],
+      "place_id": "some place id 16",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.9,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "cafe",
+        "lodging",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "store",
+        "establishment"
+      ],
+      "user_ratings_total": 60,
+      "vicinity": "Scheldestraat 15, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2103946,
+          "lng": 4.4020686
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2117151802915,
+            "lng": 4.403286930291502
+          },
+          "southwest": {
+            "lat": 51.2090172197085,
+            "lng": 4.400588969708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "De Broers van Julienne",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1242,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2038
+        }
+      ],
+      "place_id": "some place id 17",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.1,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "meal_takeaway",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 335,
+      "vicinity": "Kasteelpleinstraat 45/47, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.21393579999999,
+          "lng": 4.4067937
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2153003802915,
+            "lng": 4.408306030291503
+          },
+          "southwest": {
+            "lat": 51.2126024197085,
+            "lng": 4.405608069708498
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Het Gebaar",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 427,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 640
+        }
+      ],
+      "place_id": "some place id 18",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 4,
+      "rating": 4.7,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 362,
+      "vicinity": "Leopoldstraat 24, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.219929,
+          "lng": 4.4005703
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.22113493029149,
+            "lng": 4.403586499999999
+          },
+          "southwest": {
+            "lat": 51.2184369697085,
+            "lng": 4.399564900000001
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Da Giovanni Groenplaats TAKE OUT",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1772,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2658
+        }
+      ],
+      "place_id": "some place id 19",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 3.9,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 4311,
+      "vicinity": "Jan Blomstraat 8, Antwerpen"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 51.2193315,
+          "lng": 4.3989002
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 51.2206958802915,
+            "lng": 4.400262280291502
+          },
+          "southwest": {
+            "lat": 51.2179979197085,
+            "lng": 4.397564319708497
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Bij Lam & Yin",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 478,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 851
+        }
+      ],
+      "place_id": "some place id 20",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.6,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 151,
+      "vicinity": "Reyndersstraat 17, Antwerpen"
+    }
+  ],
+  "status": "OK"
+}

--- a/src/services/restaurants/mock/chicago.json
+++ b/src/services/restaurants/mock/chicago.json
@@ -1,0 +1,973 @@
+{
+  "html_attributions": [],
+  "next_page_token": "some token",
+  "results": [
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.886065,
+          "lng": -87.6208832
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.88758823029149,
+            "lng": -87.6194830697085
+          },
+          "southwest": {
+            "lat": 41.88489026970849,
+            "lng": -87.6221810302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Fairmont Chicago - Millennium Park",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1194,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1800
+        }
+      ],
+      "place_id": "some place id 21",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "lodging",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2085,
+      "vicinity": "200 North Columbus Drive, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.888868,
+          "lng": -87.626394
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8904151302915,
+            "lng": -87.62518896970849
+          },
+          "southwest": {
+            "lat": 41.8877171697085,
+            "lng": -87.6278869302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Trump International Hotel & Tower® Chicago",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2000,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3000
+        }
+      ],
+      "place_id": "some place id 22",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.1,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "spa",
+        "lodging",
+        "restaurant",
+        "food",
+        "gym",
+        "health",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2624,
+      "vicinity": "401 North Wabash Avenue, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8870687,
+          "lng": -87.61948509999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8887213802915,
+            "lng": -87.61806096970848
+          },
+          "southwest": {
+            "lat": 41.8860234197085,
+            "lng": -87.6207589302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Swissotel Chicago",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3024,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4032
+        }
+      ],
+      "place_id": "some place id 23",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "lodging",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 4059,
+      "vicinity": "323 East Wacker Drive, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.87156110000001,
+          "lng": -87.62728609999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8729340802915,
+            "lng": -87.62602206970848
+          },
+          "southwest": {
+            "lat": 41.8702361197085,
+            "lng": -87.6287200302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Lou Malnati's Pizzeria",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2640,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3960
+        }
+      ],
+      "place_id": "some place id 24",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "meal_delivery",
+        "meal_takeaway",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 6103,
+      "vicinity": "805 South State Street, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.88907469999999,
+          "lng": -87.62988229999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.89049998029149,
+            "lng": -87.62853766970849
+          },
+          "southwest": {
+            "lat": 41.8878020197085,
+            "lng": -87.6312356302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Siena Tavern",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 812,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1220
+        }
+      ],
+      "place_id": "some place id 25",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1906,
+      "vicinity": "51 West Kinzie Street, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8846222,
+          "lng": -87.6297111
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8859492302915,
+            "lng": -87.62826921970849
+          },
+          "southwest": {
+            "lat": 41.8832512697085,
+            "lng": -87.63096718029149
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Petterino's",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1000,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1500
+        }
+      ],
+      "place_id": "some place id 26",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1255,
+      "vicinity": "150 North Dearborn Street, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.87801039999999,
+          "lng": -87.63489799999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.87941258029149,
+            "lng": -87.63347921970849
+          },
+          "southwest": {
+            "lat": 41.87671461970849,
+            "lng": -87.6361771802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Giordano's",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 750,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1000
+        }
+      ],
+      "place_id": "some place id 27",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "meal_takeaway",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 6816,
+      "vicinity": "223 West Jackson Boulevard, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8813268,
+          "lng": -87.6246925
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8826719802915,
+            "lng": -87.62322306970849
+          },
+          "southwest": {
+            "lat": 41.8799740197085,
+            "lng": -87.6259210302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "The Gage",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1367,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 28",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2771,
+      "vicinity": "24 South Michigan Avenue, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.86886419999999,
+          "lng": -87.62456600000002
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8702152302915,
+            "lng": -87.6230221197085
+          },
+          "southwest": {
+            "lat": 41.8675172697085,
+            "lng": -87.6257200802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Yolk - South Loop",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2268,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4032
+        }
+      ],
+      "place_id": "some place id 29",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "cafe",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "store",
+        "establishment"
+      ],
+      "user_ratings_total": 3098,
+      "vicinity": "1120 South Michigan Avenue, Chicago"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 41.885236,
+          "lng": -87.631823
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8863183302915,
+            "lng": -87.6307493697085
+          },
+          "southwest": {
+            "lat": 41.8836203697085,
+            "lng": -87.6334473302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "M Burger",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 1333,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2000
+        }
+      ],
+      "place_id": "some place id 30",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 113,
+      "vicinity": "THOMPSON CENTER, 100 West Randolph Street, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8847209,
+          "lng": -87.6228606
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8859644302915,
+            "lng": -87.62155841970849
+          },
+          "southwest": {
+            "lat": 41.8832664697085,
+            "lng": -87.6242563802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/cafe-71.png",
+      "name": "Wildberry Pancakes & Cafe",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3024,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4032
+        }
+      ],
+      "place_id": "some place id 31",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.6,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "cafe",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 5639,
+      "vicinity": "130 East Randolph Street, Chicago"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 41.87925200000001,
+          "lng": -87.628406
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8806998302915,
+            "lng": -87.62706636970849
+          },
+          "southwest": {
+            "lat": 41.87800186970851,
+            "lng": -87.6297643302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "The Berghoff Restaurant",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 1200,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1800
+        }
+      ],
+      "place_id": "some place id 32",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 3042,
+      "vicinity": "17 West Adams Street, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8779176,
+          "lng": -87.6421428
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8793143802915,
+            "lng": -87.6408205197085
+          },
+          "southwest": {
+            "lat": 41.8766164197085,
+            "lng": -87.6435184802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Lou Mitchell's",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1512,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2016
+        }
+      ],
+      "place_id": "some place id 33",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.6,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 2329,
+      "vicinity": "565 West Jackson Boulevard, Chicago"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 41.8804843,
+          "lng": -87.6377693
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8818916302915,
+            "lng": -87.6364167697085
+          },
+          "southwest": {
+            "lat": 41.8791936697085,
+            "lng": -87.63911473029151
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "South Branch Tavern and Grille",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 6656,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 13312
+        }
+      ],
+      "place_id": "some place id 34",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1078,
+      "vicinity": "100 South Wacker Drive, Chicago"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 41.8864683,
+          "lng": -87.62409380000001
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8877839302915,
+            "lng": -87.62292246970848
+          },
+          "southwest": {
+            "lat": 41.8850859697085,
+            "lng": -87.62562043029149
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Sweetwater Tavern and Grille",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 717,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1080
+        }
+      ],
+      "place_id": "some place id 35",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2203,
+      "vicinity": "225 Michigan Avenue, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8730121,
+          "lng": -87.6261784
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8743669802915,
+            "lng": -87.6247206197085
+          },
+          "southwest": {
+            "lat": 41.8716690197085,
+            "lng": -87.6274185802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/bar-71.png",
+      "name": "Buddy Guy's Legends",
+      "photos": [
+        {
+          "height": 2048,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1365
+        }
+      ],
+      "place_id": "some place id 36",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.6,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "night_club",
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2118,
+      "vicinity": "700 South Wabash Avenue, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.89052059999999,
+          "lng": -87.6308469
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.89185658029149,
+            "lng": -87.6296195197085
+          },
+          "southwest": {
+            "lat": 41.88915861970849,
+            "lng": -87.63231748029152
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Frontera Grill",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2667,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4000
+        }
+      ],
+      "place_id": "some place id 37",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 2064,
+      "vicinity": "445 North Clark Street, Chicago"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 41.88231769999999,
+          "lng": -87.63612839999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.88371053029149,
+            "lng": -87.6350946697085
+          },
+          "southwest": {
+            "lat": 41.8810125697085,
+            "lng": -87.6377926302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "One North Kitchen & Bar",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 768,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1024
+        }
+      ],
+      "place_id": "some place id 38",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.1,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 322,
+      "vicinity": "1 North Upper Wacker Drive, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.88433,
+          "lng": -87.632809
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8856780802915,
+            "lng": -87.6313017697085
+          },
+          "southwest": {
+            "lat": 41.8829801197085,
+            "lng": -87.6339997302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "312 Chicago",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 757,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1024
+        }
+      ],
+      "place_id": "some place id 39",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 810,
+      "vicinity": "136 North LaSalle Street, Chicago"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 41.8880993,
+          "lng": -87.6327417
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 41.8894707302915,
+            "lng": -87.6313121197085
+          },
+          "southwest": {
+            "lat": 41.8867727697085,
+            "lng": -87.63401008029152
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Chicago Cut Steakhouse",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1533,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2239
+        }
+      ],
+      "place_id": "some place id 40",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 4,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1860,
+      "vicinity": "300 North LaSalle Drive, Chicago"
+    }
+  ],
+  "status": "OK"
+}

--- a/src/services/restaurants/mock/index.js
+++ b/src/services/restaurants/mock/index.js
@@ -1,0 +1,21 @@
+import antwerp from './antwerp.json';
+import chicago from './chicago.json';
+import toronto from './toronto.json';
+import san_francisco from './san_francisco.json';
+
+export const mocks = {
+  '51.219448,4.402464': antwerp,
+  '43.653225,-79.383186': toronto,
+  '41.878113,-87.629799': chicago,
+  '37.7749295,-122.4194155': san_francisco,
+};
+
+export const mockImages = [
+  'https://www.foodiesfeed.com/wp-content/uploads/2019/06/top-view-for-box-of-2-burgers-home-made-600x899.jpg',
+  'https://www.foodiesfeed.com/wp-content/uploads/2019/04/mae-mu-oranges-ice-600x750.jpg',
+  'https://www.foodiesfeed.com/wp-content/uploads/2020/08/detail-of-pavlova-strawberry-piece-of-cake-600x800.jpg',
+  'https://www.foodiesfeed.com/wp-content/uploads/2019/04/mae-mu-baking-600x750.jpg',
+  'https://www.foodiesfeed.com/wp-content/uploads/2019/04/mae-mu-pancakes-600x750.jpg',
+  'https://www.foodiesfeed.com/wp-content/uploads/2019/02/messy-pizza-on-a-black-table-600x400.jpg',
+  'https://www.foodiesfeed.com/wp-content/uploads/2019/02/pizza-ready-for-baking-600x400.jpg',
+];

--- a/src/services/restaurants/mock/san_francisco.json
+++ b/src/services/restaurants/mock/san_francisco.json
@@ -1,0 +1,970 @@
+{
+  "html_attributions": [],
+  "next_page_token": "some token",
+  "results": [
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77361,
+          "lng": -122.421622
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7750214302915,
+            "lng": -122.4202089697085
+          },
+          "southwest": {
+            "lat": 37.7723234697085,
+            "lng": -122.4229069302915
+          }
+        }
+      },
+      "ix": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Zuni Café",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3672,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 6786
+        }
+      ],
+      "place_id": "some place id 41",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "cafe",
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1675,
+      "vicinity": "1658 Market Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7829132,
+          "lng": -122.4188995
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.78423678029149,
+            "lng": -122.4176706197085
+          },
+          "southwest": {
+            "lat": 37.78153881970849,
+            "lng": -122.4203685802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Brenda's French Soul Food",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2322,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4128
+        }
+      ],
+      "place_id": "some place id 42",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 4404,
+      "vicinity": "652 Polk Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7710938,
+          "lng": -122.4126502
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7723741302915,
+            "lng": -122.4114229697085
+          },
+          "southwest": {
+            "lat": 37.7696761697085,
+            "lng": -122.4141209302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/bar-71.png",
+      "name": "DNA Lounge",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 576,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1024
+        }
+      ],
+      "place_id": "some place id 43",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "night_club",
+        "cafe",
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1284,
+      "vicinity": "375 11th Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77710419999999,
+          "lng": -122.4227403
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7783638802915,
+            "lng": -122.4215429197085
+          },
+          "southwest": {
+            "lat": 37.7756659197085,
+            "lng": -122.4242408802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Absinthe Brasserie & Bar",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 468,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 960
+        }
+      ],
+      "place_id": "some place id 44",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1405,
+      "vicinity": "398 Hayes Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77219169999999,
+          "lng": -122.4306187
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.77349423029149,
+            "lng": -122.4293135697085
+          },
+          "southwest": {
+            "lat": 37.7707962697085,
+            "lng": -122.4320115302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "YH - BEIJING",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2268,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4032
+        }
+      ],
+      "place_id": "some place id 45",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 1,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 191,
+      "vicinity": "500 Haight Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77002299999999,
+          "lng": -122.4221172
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.77136293029149,
+            "lng": -122.4209095697085
+          },
+          "southwest": {
+            "lat": 37.76866496970849,
+            "lng": -122.4236075302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Zeitgeist",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 1000,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1500
+        }
+      ],
+      "place_id": "some place id 46",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 1,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2488,
+      "vicinity": "199 Valencia Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7648313,
+          "lng": -122.4211374
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7662523302915,
+            "lng": -122.4198115697085
+          },
+          "southwest": {
+            "lat": 37.7635543697085,
+            "lng": -122.4225095302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Pancho Villa Taqueria",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1536,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 47",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 1,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 2921,
+      "vicinity": "3071 16th Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7647206,
+          "lng": -122.422986
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7661346802915,
+            "lng": -122.4216562197085
+          },
+          "southwest": {
+            "lat": 37.76343671970851,
+            "lng": -122.4243541802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "The Monk's Kettle",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 1280,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 48",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "restaurant",
+        "bar",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1392,
+      "vicinity": "3141 16th Street, San Francisco"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 37.7715178,
+          "lng": -122.412761
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.77287373029149,
+            "lng": -122.4114934197085
+          },
+          "southwest": {
+            "lat": 37.77017576970849,
+            "lng": -122.4141913802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/bar-71.png",
+      "name": "Bar Agricole",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 2791,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3837
+        }
+      ],
+      "place_id": "some place id 49",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 490,
+      "vicinity": "355 11th Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.769775,
+          "lng": -122.4120333
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7711120302915,
+            "lng": -122.4105037697085
+          },
+          "southwest": {
+            "lat": 37.76841406970851,
+            "lng": -122.4132017302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "SoMa StrEat Food Park",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3571,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5357
+        }
+      ],
+      "place_id": "some place id 50",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "hair_care",
+        "restaurant",
+        "food",
+        "health",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1644,
+      "vicinity": "428 11th Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77631340000001,
+          "lng": -122.4264188
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7777280802915,
+            "lng": -122.4250006697085
+          },
+          "southwest": {
+            "lat": 37.7750301197085,
+            "lng": -122.4276986302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Suppenküche",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 1365,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 51",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 1344,
+      "vicinity": "525 Laguna Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77847149999999,
+          "lng": -122.4121645
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7800643802915,
+            "lng": -122.4112009697085
+          },
+          "southwest": {
+            "lat": 37.77736641970851,
+            "lng": -122.4138989302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/shopping-71.png",
+      "name": "City Beer Store",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 2218,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4656
+        }
+      ],
+      "place_id": "some place id 52",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.6,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "liquor_store",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "store",
+        "establishment"
+      ],
+      "user_ratings_total": 977,
+      "vicinity": "1148 Mission Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.785519,
+          "lng": -122.421811
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7869324802915,
+            "lng": -122.4203096197085
+          },
+          "southwest": {
+            "lat": 37.78423451970851,
+            "lng": -122.4230075802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Tommy's Joynt",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 583,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1255
+        }
+      ],
+      "place_id": "some place id 53",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 1,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "store",
+        "establishment"
+      ],
+      "user_ratings_total": 3184,
+      "vicinity": "1101 Geary Boulevard, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7644599,
+          "lng": -122.4220487
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7658183802915,
+            "lng": -122.4206096697085
+          },
+          "southwest": {
+            "lat": 37.7631204197085,
+            "lng": -122.4233076302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Limón Rotisserie",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 3671,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5689
+        }
+      ],
+      "place_id": "some place id 54",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 1399,
+      "vicinity": "524 Valencia Street, San Francisco"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 37.7771677,
+          "lng": -122.4218207
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7784544802915,
+            "lng": -122.4204300697085
+          },
+          "southwest": {
+            "lat": 37.7757565197085,
+            "lng": -122.4231280302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Hayes Street Grill",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 1365,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 55",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 214,
+      "vicinity": "320 Hayes Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7735005,
+          "lng": -122.4217368
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7747977802915,
+            "lng": -122.4203520197085
+          },
+          "southwest": {
+            "lat": 37.7720998197085,
+            "lng": -122.4230499802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/bar-71.png",
+      "name": "Pause Wine Bar in Hayes Valley",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 2048,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 56",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 82,
+      "vicinity": "1666 Market Street, San Francisco"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 37.775043,
+          "lng": -122.412832
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7764133802915,
+            "lng": -122.4116205697085
+          },
+          "southwest": {
+            "lat": 37.7737154197085,
+            "lng": -122.4143185302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "AsiaSF",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 3456,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5184
+        }
+      ],
+      "place_id": "some place id 57",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "night_club",
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 457,
+      "vicinity": "201 9th Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.7861185,
+          "lng": -122.4115102
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7874766802915,
+            "lng": -122.4101005197085
+          },
+          "southwest": {
+            "lat": 37.7847787197085,
+            "lng": -122.4127984802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Jasper's Corner Tap and Kitchen",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2668,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4000
+        }
+      ],
+      "place_id": "some place id 58",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 3.8,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 549,
+      "vicinity": "401 Taylor Street, San Francisco"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 37.7839584,
+          "lng": -122.40905
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.7853146802915,
+            "lng": -122.4077999697085
+          },
+          "southwest": {
+            "lat": 37.7826167197085,
+            "lng": -122.4104979302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/bar-71.png",
+      "name": "Mikkeller Bar",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 667,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1000
+        }
+      ],
+      "place_id": "some place id 59",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2630,
+      "vicinity": "34 Mason Street, San Francisco"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 37.77653919999999,
+          "lng": -122.4249244
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 37.77793988029149,
+            "lng": -122.4235858197085
+          },
+          "southwest": {
+            "lat": 37.77524191970849,
+            "lng": -122.4262837802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Patxi's Pizza",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2313,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3167
+        }
+      ],
+      "place_id": "some place id 60",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 861,
+      "vicinity": "511 Hayes Street, San Francisco"
+    }
+  ],
+  "status": "OK"
+}

--- a/src/services/restaurants/mock/toronto.json
+++ b/src/services/restaurants/mock/toronto.json
@@ -1,0 +1,946 @@
+{
+  "html_attributions": [],
+  "next_page_token": "some token",
+  "results": [
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6465623,
+          "lng": -79.374578
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.64794098029149,
+            "lng": -79.37325551970848
+          },
+          "southwest": {
+            "lat": 43.6452430197085,
+            "lng": -79.37595348029149
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Novotel Toronto Centre",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 4910,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 6576
+        }
+      ],
+      "place_id": "some place id 61",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "lodging",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1822,
+      "vicinity": "45 The Esplanade, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6460303,
+          "lng": -79.381388
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6471657802915,
+            "lng": -79.3799530197085
+          },
+          "southwest": {
+            "lat": 43.6444678197085,
+            "lng": -79.3826509802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "Fairmont Royal York",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 2048,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1621
+        }
+      ],
+      "place_id": "some place id 62",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "lodging",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 8383,
+      "vicinity": "100 Front Street West, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.65,
+          "lng": -79.39638889999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6512747302915,
+            "lng": -79.39500986970849
+          },
+          "southwest": {
+            "lat": 43.6485767697085,
+            "lng": -79.3977078302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/lodging-71.png",
+      "name": "HOTEL OCHO",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1924,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 3598
+        }
+      ],
+      "place_id": "some place id 63",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "lodging",
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 502,
+      "vicinity": "195 Spadina Avenue, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.64696989999999,
+          "lng": -79.3932324
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.64837233029149,
+            "lng": -79.3916331697085
+          },
+          "southwest": {
+            "lat": 43.64567436970849,
+            "lng": -79.3943311302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Marquis Lounge and Bistro",
+      "photos": [
+        {
+          "height": 1500,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 64",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "restaurant",
+        "bar",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 9,
+      "vicinity": "92 Peter Street, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.64723610000001,
+          "lng": -79.3765722
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.64853203029149,
+            "lng": -79.3754588697085
+          },
+          "southwest": {
+            "lat": 43.64583406970849,
+            "lng": -79.3781568302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Oliver & Bonacini Café Grill, Yonge & Front",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 480,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 640
+        }
+      ],
+      "place_id": "some place id 65",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "restaurant",
+        "night_club",
+        "bar",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1382,
+      "vicinity": "33 Yonge Street, Toronto"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 43.6574337,
+          "lng": -79.3832666
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6588368302915,
+            "lng": -79.38194011970849
+          },
+          "southwest": {
+            "lat": 43.6561388697085,
+            "lng": -79.38463808029151
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Adega Restaurante",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 3456,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4608
+        }
+      ],
+      "place_id": "some place id 66",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 405,
+      "vicinity": "33 Elm Street, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.650916,
+          "lng": -79.375685
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6523067302915,
+            "lng": -79.3743523697085
+          },
+          "southwest": {
+            "lat": 43.64960876970851,
+            "lng": -79.37705033029151
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Terroni",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3840,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5760
+        }
+      ],
+      "place_id": "some place id 67",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 3698,
+      "vicinity": "57 Adelaide Street East, Toronto"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 43.6499945,
+          "lng": -79.3839517
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6512935302915,
+            "lng": -79.3828103697085
+          },
+          "southwest": {
+            "lat": 43.6485955697085,
+            "lng": -79.3855083302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "The Keg Steakhouse + Bar - York Street",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 2268,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4032
+        }
+      ],
+      "place_id": "some place id 68",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 2954,
+      "vicinity": "165 York Street, Toronto"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 43.6479063,
+          "lng": -79.3780646
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.64915643029151,
+            "lng": -79.3766743197085
+          },
+          "southwest": {
+            "lat": 43.64645846970851,
+            "lng": -79.3793722802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Jump Restaurant",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 636,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 960
+        }
+      ],
+      "place_id": "some place id 69",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 781,
+      "vicinity": "18 Wellington Street West, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.655701,
+          "lng": -79.37917499999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6570138802915,
+            "lng": -79.37781131970848
+          },
+          "southwest": {
+            "lat": 43.6543159197085,
+            "lng": -79.38050928029149
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "The Senator",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 2048,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 70",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 1371,
+      "vicinity": "249 Victoria Street, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6573753,
+          "lng": -79.383461
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6587842802915,
+            "lng": -79.38213851970849
+          },
+          "southwest": {
+            "lat": 43.6560863197085,
+            "lng": -79.3848364802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Donatello Restaurant",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 2048,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1902
+        }
+      ],
+      "place_id": "some place id 71",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 798,
+      "vicinity": "37 Elm Street, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6475793,
+          "lng": -79.38090369999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6486975802915,
+            "lng": -79.3795757197085
+          },
+          "southwest": {
+            "lat": 43.6459996197085,
+            "lng": -79.3822736802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Canoe",
+      "opening_hours": {
+        "open_now": false
+      },
+      "photos": [
+        {
+          "height": 2988,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5312
+        }
+      ],
+      "place_id": "some place id 72",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 4,
+      "rating": 4.5,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 2019,
+      "vicinity": "66 Wellington Street West 54th floor, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.64541,
+          "lng": -79.383865
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6465791802915,
+            "lng": -79.3824437197085
+          },
+          "southwest": {
+            "lat": 43.6438812197085,
+            "lng": -79.38514168029151
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Jack Astor's Bar & Grill",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3024,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 4032
+        }
+      ],
+      "place_id": "some place id 73",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.1,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 4973,
+      "vicinity": "144 Front Street West, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6576597,
+          "lng": -79.381692
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6590311302915,
+            "lng": -79.38024316970849
+          },
+          "southwest": {
+            "lat": 43.6563331697085,
+            "lng": -79.3829411302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Salad King",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1200,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1343
+        }
+      ],
+      "place_id": "some place id 74",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 1,
+      "rating": 4.3,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 3669,
+      "vicinity": "340 Yonge Street, Toronto"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 43.64735829999999,
+          "lng": -79.3866278
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6486633302915,
+            "lng": -79.38526061970849
+          },
+          "southwest": {
+            "lat": 43.6459653697085,
+            "lng": -79.38795858029151
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "IL FORNELLO on King",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 1200,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1800
+        }
+      ],
+      "place_id": "some place id 75",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.1,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "meal_delivery",
+        "meal_takeaway",
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 763,
+      "vicinity": "214 King Street West, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6502346,
+          "lng": -79.3889547
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6516236302915,
+            "lng": -79.3876224697085
+          },
+          "southwest": {
+            "lat": 43.6489256697085,
+            "lng": -79.39032043029151
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "Little India Restaurant",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1365,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 76",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "meal_takeaway",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1976,
+      "vicinity": "255 Queen Street West, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6470917,
+          "lng": -79.37404169999999
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6483725802915,
+            "lng": -79.37263056970849
+          },
+          "southwest": {
+            "lat": 43.6456746197085,
+            "lng": -79.3753285302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/bar-71.png",
+      "name": "Scotland Yard Pub",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 1055,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 2048
+        }
+      ],
+      "place_id": "some place id 77",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 4.2,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "bar",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1202,
+      "vicinity": "56 The Esplanade, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.64624899999999,
+          "lng": -79.390453
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.64768978029149,
+            "lng": -79.3891442697085
+          },
+          "southwest": {
+            "lat": 43.64499181970849,
+            "lng": -79.3918422302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "309 Dhaba Indian Restaurant of Excellence",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 731,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 1024
+        }
+      ],
+      "place_id": "some place id 78",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 2,
+      "rating": 3.3,
+      "reference": "",
+      "scope": "",
+      "types": [
+        "meal_delivery",
+        "restaurant",
+        "food",
+        "point_of_interest",
+        "establishment"
+      ],
+      "user_ratings_total": 1410,
+      "vicinity": "309 King Street West, Toronto"
+    },
+    {
+      "business_status": "CLOSED_TEMPORARILY",
+      "geometry": {
+        "location": {
+          "lat": 43.6503155,
+          "lng": -79.3847182
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.6517116802915,
+            "lng": -79.3833894197085
+          },
+          "southwest": {
+            "lat": 43.6490137197085,
+            "lng": -79.3860873802915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "VOLOS",
+      "permanently_closed": true,
+      "photos": [
+        {
+          "height": 3522,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5283
+        }
+      ],
+      "place_id": "some place id 79",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 763,
+      "vicinity": "133 Richmond Street West, Toronto"
+    },
+    {
+      "business_status": "OPERATIONAL",
+      "geometry": {
+        "location": {
+          "lat": 43.6506177,
+          "lng": -79.3882088
+        },
+        "viewport": {
+          "northeast": {
+            "lat": 43.65190503029149,
+            "lng": -79.3868345697085
+          },
+          "southwest": {
+            "lat": 43.6492070697085,
+            "lng": -79.3895325302915
+          }
+        }
+      },
+      "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/v1/png_71/restaurant-71.png",
+      "name": "PLANTA Queen",
+      "opening_hours": {
+        "open_now": true
+      },
+      "photos": [
+        {
+          "height": 3840,
+          "html_attributions": [""],
+          "photo_reference": "",
+          "width": 5760
+        }
+      ],
+      "place_id": "some place id 80",
+      "plus_code": {
+        "compound_code": "",
+        "global_code": ""
+      },
+      "price_level": 3,
+      "rating": 4.4,
+      "reference": "",
+      "scope": "",
+      "types": ["restaurant", "food", "point_of_interest", "establishment"],
+      "user_ratings_total": 1064,
+      "vicinity": "180 Queen Street West, Toronto"
+    }
+  ],
+  "status": "OK"
+}

--- a/src/services/restaurants/restaurants.service.js
+++ b/src/services/restaurants/restaurants.service.js
@@ -1,0 +1,24 @@
+import { mocks } from './mock';
+import camelize from 'camelize';
+
+export const restaurantsRequest = (location = '37.7749295,-122.4194155') => {
+  return new Promise((resolve, reject) => {
+    const mock = mocks[location];
+    if (!mock) {
+      reject('not found');
+    }
+    resolve(mock);
+  });
+};
+
+export const restaurantsTransform = ({ results = [] }) => {
+  const mappedResults = results.map((restaurant) => {
+    return {
+      ...restaurant,
+      isOpenNow: restaurant.opening_hours && restaurant.opening_hours.open_now,
+      isClosedTemporarily: restaurant.business_status === 'CLOSED_TEMPORARILY',
+    };
+  });
+
+  return camelize(mappedResults);
+};

--- a/src/services/restaurants/restaurants.service.js
+++ b/src/services/restaurants/restaurants.service.js
@@ -1,4 +1,4 @@
-import { mocks } from './mock';
+import { mocks, mockImages } from './mock';
 import camelize from 'camelize';
 
 export const restaurantsRequest = (location = '37.7749295,-122.4194155') => {
@@ -13,6 +13,9 @@ export const restaurantsRequest = (location = '37.7749295,-122.4194155') => {
 
 export const restaurantsTransform = ({ results = [] }) => {
   const mappedResults = results.map((restaurant) => {
+    restaurant.photos = restaurant.photos.map(() => {
+      return mockImages[Math.ceil(Math.random() * (mockImages.length - 1))];
+    });
     return {
       ...restaurant,
       isOpenNow: restaurant.opening_hours && restaurant.opening_hours.open_now,


### PR DESCRIPTION
## Changes
* Created a `mock` dir in  `/src/services/restaurants` to hold mock Google Places restaurant data
* Created initial service request and `ContextProvider` for managing and rendering mock restaurants data
* Added `camelize` package to camel-case restaurant data properties return from the Promise request
* Updated screen component of restaurants to use data managed by its ContextAPI
* Created an extended custom loader from `react-native-paper` package to render on restaurants loading