### PR TITLE
Optimize and add stack navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,51 +1,15 @@
 import { StatusBar as ExpoStatusBar } from 'expo-status-bar';
 import AppLoading from 'expo-app-loading';
 import React from 'react';
-import { Text } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { ThemeProvider } from 'styled-components/native';
 
-import { Ionicons } from '@expo/vector-icons';
 import { useFonts, Oswald_400Regular } from '@expo-google-fonts/oswald';
 import { Lato_400Regular } from '@expo-google-fonts/lato';
 
 import { theme } from './src/infrastructure/theme';
-import { SafeArea } from './src/components/SafeArea/SafeArea';
-import { RestaurantsScreen } from './src/features/restaurants/screens/RestaurantsScreen';
+import { Navigation } from './src/infrastructure/navigation';
 import { RestaurantsContextProvider } from './src/services/restaurants/RestaurantsContext';
 import { LocationContextProvider } from './src/services/location/LocationContext';
-
-const TAB_ICON = {
-  Restaurants: 'restaurant',
-  Map: 'map',
-  Settings: 'settings',
-};
-
-// ===== Mock Screen Components ===== //
-const Map = () => (
-  <SafeArea>
-    <Text>Maps!</Text>
-  </SafeArea>
-);
-const Settings = () => (
-  <SafeArea>
-    <Text>Settings!</Text>
-  </SafeArea>
-);
-// ===== Mock Screen Components ===== //
-
-const createScreenOptions = ({ route }) => {
-  const iconName = TAB_ICON[route.name];
-
-  return {
-    tabBarIcon: ({ size, color }) => (
-      <Ionicons name={iconName} size={size} color={color} />
-    ),
-  };
-};
-
-const Tab = createBottomTabNavigator();
 
 export default function App() {
   const [fontsLoaded] = useFonts({
@@ -61,22 +25,7 @@ export default function App() {
         <ThemeProvider theme={theme}>
           <LocationContextProvider>
             <RestaurantsContextProvider>
-              <NavigationContainer>
-                <Tab.Navigator
-                  screenOptions={createScreenOptions}
-                  tabBarOptions={{
-                    activeTintColor: 'tomato',
-                    inactiveTintColor: 'gray',
-                  }}
-                >
-                  <Tab.Screen
-                    name="Restaurants"
-                    component={RestaurantsScreen}
-                  />
-                  <Tab.Screen name="Map" component={Map} />
-                  <Tab.Screen name="Settings" component={Settings} />
-                </Tab.Navigator>
-              </NavigationContainer>
+              <Navigation />
             </RestaurantsContextProvider>
           </LocationContextProvider>
         </ThemeProvider>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-native-community/masked-view": "0.1.10",
     "@react-navigation/bottom-tabs": "^5.11.11",
     "@react-navigation/native": "^5.9.4",
+    "@react-navigation/stack": "^5.14.5",
     "camelize": "^1.0.0",
     "expo": "~41.0.1",
     "expo-app-loading": "^1.0.3",

--- a/src/features/restaurants/screens/RestaurantDetailScreen.js
+++ b/src/features/restaurants/screens/RestaurantDetailScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { SafeArea } from '../../../components/SafeArea/SafeArea';
+import { RestaurantInfoCard } from '../components/RestaurantInfoCard';
+
+export const RestaurantDetailScreen = ({ route }) => {
+  const { restaurant } = route.params;
+
+  return (
+    <SafeArea>
+      <RestaurantInfoCard restaurant={restaurant} />
+    </SafeArea>
+  );
+};

--- a/src/features/restaurants/screens/RestaurantsScreen.js
+++ b/src/features/restaurants/screens/RestaurantsScreen.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { FlatList, View } from 'react-native';
+import { FlatList, View, TouchableOpacity } from 'react-native';
 import { ActivityIndicator, Colors } from 'react-native-paper';
 import styled from 'styled-components/native';
 
@@ -26,7 +26,7 @@ const Loading = styled(ActivityIndicator)`
   margin-left: -25px;
 `;
 
-export const RestaurantsScreen = () => {
+export const RestaurantsScreen = ({ navigation }) => {
   const { restaurants, isLoading } = useContext(RestaurantsContext);
 
   return (
@@ -41,9 +41,15 @@ export const RestaurantsScreen = () => {
         data={restaurants}
         renderItem={({ item }) => {
           return (
-            <Spacer position="bottom" size="large">
-              <RestaurantInfoCard restaurant={item} />
-            </Spacer>
+            <TouchableOpacity
+              onPress={() =>
+                navigation.navigate('RestaurantDetail', { restaurant: item })
+              }
+            >
+              <Spacer position="bottom" size="large">
+                <RestaurantInfoCard restaurant={item} />
+              </Spacer>
+            </TouchableOpacity>
           );
         }}
         keyExtractor={(item) => item.name}

--- a/src/infrastructure/navigation/AppNavigator.js
+++ b/src/infrastructure/navigation/AppNavigator.js
@@ -6,7 +6,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Ionicons } from '@expo/vector-icons';
 
 import { SafeArea } from '../../components/SafeArea/SafeArea';
-import { RestaurantsScreen } from '../../features/restaurants/screens/RestaurantsScreen';
+import { RestaurantsNavigator } from './RestaurantsNavigator';
 
 const TAB_ICON = {
   Restaurants: 'restaurant',
@@ -48,7 +48,7 @@ export const AppNavigator = () => (
         inactiveTintColor: 'gray',
       }}
     >
-      <Tab.Screen name="Restaurants" component={RestaurantsScreen} />
+      <Tab.Screen name="Restaurants" component={RestaurantsNavigator} />
       <Tab.Screen name="Map" component={Map} />
       <Tab.Screen name="Settings" component={Settings} />
     </Tab.Navigator>

--- a/src/infrastructure/navigation/AppNavigator.js
+++ b/src/infrastructure/navigation/AppNavigator.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+import { Ionicons } from '@expo/vector-icons';
+
+import { SafeArea } from '../../components/SafeArea/SafeArea';
+import { RestaurantsScreen } from '../../features/restaurants/screens/RestaurantsScreen';
+
+const TAB_ICON = {
+  Restaurants: 'restaurant',
+  Map: 'map',
+  Settings: 'settings',
+};
+
+const Tab = createBottomTabNavigator();
+
+// ===== Mock Screen Components ===== //
+const Map = () => (
+  <SafeArea>
+    <Text>Maps!</Text>
+  </SafeArea>
+);
+const Settings = () => (
+  <SafeArea>
+    <Text>Settings!</Text>
+  </SafeArea>
+);
+// ===== Mock Screen Components ===== //
+
+const createScreenOptions = ({ route }) => {
+  const iconName = TAB_ICON[route.name];
+
+  return {
+    tabBarIcon: ({ size, color }) => (
+      <Ionicons name={iconName} size={size} color={color} />
+    ),
+  };
+};
+
+export const AppNavigator = () => (
+  <NavigationContainer>
+    <Tab.Navigator
+      screenOptions={createScreenOptions}
+      tabBarOptions={{
+        activeTintColor: 'tomato',
+        inactiveTintColor: 'gray',
+      }}
+    >
+      <Tab.Screen name="Restaurants" component={RestaurantsScreen} />
+      <Tab.Screen name="Map" component={Map} />
+      <Tab.Screen name="Settings" component={Settings} />
+    </Tab.Navigator>
+  </NavigationContainer>
+);

--- a/src/infrastructure/navigation/RestaurantsNavigator.js
+++ b/src/infrastructure/navigation/RestaurantsNavigator.js
@@ -1,16 +1,27 @@
 import React from 'react';
-import { createStackNavigator } from '@react-navigation/stack';
+import {
+  createStackNavigator,
+  TransitionPresets,
+} from '@react-navigation/stack';
 
 import { RestaurantsScreen } from '../../features/restaurants/screens/RestaurantsScreen';
+import { RestaurantDetailScreen } from '../../features/restaurants/screens/RestaurantDetailScreen';
 
 const RestaurantStack = createStackNavigator();
 
 export const RestaurantsNavigator = () => {
   return (
-    <RestaurantStack.Navigator headerMode="none">
+    <RestaurantStack.Navigator
+      headerMode="none"
+      screenOptions={{ ...TransitionPresets.ModalPresentationIOS }}
+    >
       <RestaurantStack.Screen
         name="Restaurants"
         component={RestaurantsScreen}
+      />
+      <RestaurantStack.Screen
+        name="RestaurantDetail"
+        component={RestaurantDetailScreen}
       />
     </RestaurantStack.Navigator>
   );

--- a/src/infrastructure/navigation/RestaurantsNavigator.js
+++ b/src/infrastructure/navigation/RestaurantsNavigator.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { createStackNavigator } from '@react-navigation/stack';
+
+import { RestaurantsScreen } from '../../features/restaurants/screens/RestaurantsScreen';
+
+const RestaurantStack = createStackNavigator();
+
+export const RestaurantsNavigator = () => {
+  return (
+    <RestaurantStack.Navigator headerMode="none">
+      <RestaurantStack.Screen
+        name="Restaurants"
+        component={RestaurantsScreen}
+      />
+    </RestaurantStack.Navigator>
+  );
+};

--- a/src/infrastructure/navigation/index.js
+++ b/src/infrastructure/navigation/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AppNavigator } from './AppNavigator';
+
+export const Navigation = () => {
+  return <AppNavigator />;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,6 +1911,14 @@
   dependencies:
     nanoid "^3.1.15"
 
+"@react-navigation/stack@^5.14.5":
+  version "5.14.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.14.5.tgz#dc615cd7d270ba79e3330dcb50c2819d0e1f3850"
+  integrity sha512-hpdn1SS0tc3/3atkV2Q2y++n5B4e0rUcCj4W43PODMu72yX2m0LkKAAcpkPDCWAvwnLLIoLAEl5BEifZigl/6A==
+  dependencies:
+    color "^3.1.3"
+    react-native-iphone-x-helper "^1.3.0"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz"


### PR DESCRIPTION
## Changes
* Add `@react-navigation/stack` dependency for implementing stack navigation
* Add new screen for displaying individual restaurant details
* Set restaurant detail screen as a navigation stack to the restaurant info card list
* Set wrapper component around the restaurant info card to display an opacity feedback for better UX on touch interaction
* Set default screen transition on the restaurants navigation stack to the standard iOS modal presentation style (_**from bottom up)**_
* Restructure navigation feature files to a separate folder under `/src/infrastructure/navigation`